### PR TITLE
Fix writing for simple types true,false,null,undef

### DIFF
--- a/src/cb0r.c
+++ b/src/cb0r.c
@@ -402,10 +402,10 @@ uint8_t cb0r_write(uint8_t *out, cb0r_e type, uint64_t number)
     case CB0R_BASE64: number = 22; break;
     case CB0R_HEX: number = 23; break;
     case CB0R_DATA: number = 24; break;
-    case CB0R_FALSE: number = 25; break;
-    case CB0R_TRUE: number = 20; break;
-    case CB0R_NULL: number = 21; break;
-    case CB0R_UNDEF: number = 22; break;
+    case CB0R_FALSE: type = CB0R_SIMPLE; number = 20; break;
+    case CB0R_TRUE: type = CB0R_SIMPLE; number = 21; break;
+    case CB0R_NULL: type = CB0R_SIMPLE; number = 22; break;
+    case CB0R_UNDEF: type = CB0R_SIMPLE; number = 23; break;
     case CB0R_FLOAT: { // incoming number is size of float
       if(number == 2) number = 25;
       else if(number == 4) number = 26;


### PR DESCRIPTION
Previously, writing simple types was not in line with the CBOR
standard. Writing the array [false,true,null,undefined] would
result in 84 38 54 75 96 which is totally off.
This is now fixed and correctly returns 84 f4 f5 f6 f7, which
can be decoded correctly.

You can also check https://datatracker.ietf.org/doc/html/rfc7049#section-2.3 table 2.
You can test the output by replacing the `bin/cb0r.c` with the following content. Then run `make` and `bin/cb0r` afterward.

```c
#include <stdio.h>
#include "cb0r.h"

int main(int argc, char **argv) {

  uint8_t my_cbor[8] = {0};
  uint8_t *writer = my_cbor;
  cb0r_write(writer++, CB0R_ARRAY, 4);
  cb0r_write(writer++, CB0R_FALSE, 0);
  cb0r_write(writer++, CB0R_TRUE, 0);
  cb0r_write(writer++, CB0R_NULL, 0);
  cb0r_write(writer++, CB0R_UNDEF, 0);

  for (size_t i = 0; i < sizeof(my_cbor); i++) {
    printf("%02x ", my_cbor[i]);
  }
  printf("\n");

  return 0;
}
```